### PR TITLE
WIP: Fix bug on multistep

### DIFF
--- a/Classes/ViewHelpers/Form/UploadedResourceViewHelper.php
+++ b/Classes/ViewHelpers/Form/UploadedResourceViewHelper.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WapplerSystems\FormExtended\ViewHelpers\Form;
+
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+use TYPO3\CMS\Extbase\Property\PropertyMapper;
+use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
+
+/**
+ * This ViewHelper makes the specified Image object available for its
+ * childNodes.
+ * In case the form is redisplayed because of validation errors, a previously
+ * uploaded image will be correctly used.
+ *
+ * Scope: frontend
+ */
+class UploadedResourceViewHelper extends AbstractFormFieldViewHelper
+{
+    /**
+     * @var string
+     */
+    protected $tagName = 'input';
+
+    protected HashService $hashService;
+    protected PropertyMapper $propertyMapper;
+
+    public function injectHashService(HashService $hashService)
+    {
+        $this->hashService = $hashService;
+    }
+
+    public function injectPropertyMapper(PropertyMapper $propertyMapper)
+    {
+        $this->propertyMapper = $propertyMapper;
+    }
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('as', 'string', '');
+        $this->registerArgument('accept', 'array', 'Values for the accept attribute', false, []);
+        $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this ViewHelper', false, 'f3-form-error');
+        $this->registerTagAttribute('disabled', 'string', 'Specifies that the input element should be disabled when the page loads');
+        $this->registerTagAttribute('multiple', 'string', 'Specifies that the file input element should allow multiple selection of files');
+        $this->registerUniversalTagAttributes();
+    }
+
+    public function render(): string
+    {
+        $output = '';
+
+        $name = $this->getName();
+        $as = $this->arguments['as'];
+        $accept = $this->arguments['accept'];
+        $resource = $this->getUploadedResource();
+
+        if (!empty($accept)) {
+            $this->tag->addAttribute('accept', implode(',', $accept));
+        }
+
+        if ($resource !== null) {
+            $resourcePointerIdAttribute = '';
+            if ($this->hasArgument('id')) {
+                $resourcePointerIdAttribute = ' id="' . htmlspecialchars($this->arguments['id']) . '-file-reference"';
+            }
+
+            if(is_array($resource)) {
+                foreach ($resource as $item) {
+                   $this->addFileInFormFrontend($item, $resourcePointerIdAttribute, $as, $output);
+                }
+            } else {
+                $this->addFileInFormFrontend($resource, $resourcePointerIdAttribute, $as, $output);
+            }
+        }
+
+        foreach (['name', 'type', 'tmp_name', 'error', 'size'] as $fieldName) {
+            $this->registerFieldNameForFormTokenGeneration($name . '[' . $fieldName . ']');
+        }
+        $this->tag->addAttribute('type', 'file');
+
+        if (isset($this->arguments['multiple'])) {
+            $this->tag->addAttribute('name', $name . '[]');
+        } else {
+            $this->tag->addAttribute('name', $name);
+        }
+
+        $this->setErrorClassAttribute();
+        $output .= $this->tag->render();
+
+        return $output;
+    }
+
+    /**
+     * Return a previously uploaded resource.
+     * Return NULL if errors occurred during property mapping for this property.
+     */
+    protected function getUploadedResource()
+    {
+        if ($this->getMappingResultsForProperty()->hasErrors()) {
+            return null;
+        }
+        $resource = $this->getValueAttribute();
+
+
+
+        if (is_array($resource)) {
+            $collector = [];
+
+            foreach ($resource as $item) {
+                $item instanceof FileReference
+                    ? $collector[] = $item
+                    : $this->propertyMapper->convert($item, FileReference::class);
+            }
+            return $collector;
+        }
+        if ($resource instanceof FileReference) {
+            return $resource;
+        }
+
+        return $this->propertyMapper->convert($resource, FileReference::class);
+    }
+
+    protected function addFileInFormFrontend($resource, $resourcePointerIdAttribute, $as, &$output) {
+        $resourcePointerValue = $resource->getUid();
+        if ($resourcePointerValue === null) {
+            // Newly created file reference which is not persisted yet.
+            // Use the file UID instead, but prefix it with "file:" to communicate this to the type converter
+            $resourcePointerValue = 'file:' . $resource->getOriginalResource()->getOriginalFile()->getUid();
+        }
+
+        $output .= '<input type="hidden" name="' . htmlspecialchars($this->getName()) . '[submittedFile][resourcePointer]" value="' . htmlspecialchars($this->hashService->appendHmac((string)$resourcePointerValue)) . '"' . $resourcePointerIdAttribute . ' />';
+        $this->templateVariableContainer->add($as, $resource);
+        $output .= $this->renderChildren();
+        $this->templateVariableContainer->remove($as);
+    }
+}

--- a/Resources/Private/Frontend/Partials/FileUpload.html
+++ b/Resources/Private/Frontend/Partials/FileUpload.html
@@ -1,30 +1,35 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:formvh="http://typo3.org/ns/TYPO3/CMS/Form/ViewHelpers" data-namespace-typo3-fluid="true">
+<html
+        xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+        xmlns:formvh="http://typo3.org/ns/TYPO3/CMS/Form/ViewHelpers"
+        xmlns:svewap="http://typo3.org/ns/WapplerSystems/FormExtended/ViewHelpers"
+        data-namespace-typo3-fluid="true"
+>
 <formvh:renderRenderable renderable="{element}">
     <f:render partial="Field/Field" arguments="{element: element}" contentAs="elementContent">
-        <formvh:form.uploadedResource
-            property="{element.identifier}"
-            as="resource"
-            id="{element.uniqueIdentifier}"
-            class="{element.properties.elementClassAttribute}"
-            errorClass="{element.properties.elementErrorClassAttribute}"
-            additionalAttributes="{formvh:translateElementProperty(element: element, property: 'fluidAdditionalAttributes')}"
-            accept="{element.properties.allowedMimeTypes}"
-            multiple="{f:if(condition:element.properties.multiple,then:'1')}"
+        <svewap:form.uploadedResource
+                property="{element.identifier}"
+                as="resource"
+                id="{element.uniqueIdentifier}"
+                class="{element.properties.elementClassAttribute}"
+                errorClass="{element.properties.elementErrorClassAttribute}"
+                additionalAttributes="{formvh:translateElementProperty(element: element, property: 'fluidAdditionalAttributes')}"
+                accept="{element.properties.allowedMimeTypes}"
+                multiple="{f:if(condition:element.properties.multiple,then:'1')}"
         >
             <f:if condition="{resource}">
                 <div id="{element.uniqueIdentifier}-preview">
                     {resource.originalResource.originalFile.name}
                 </div>
             </f:if>
-        </formvh:form.uploadedResource>
+        </svewap:form.uploadedResource>
         <f:if condition="{element.properties.multiple}">
             <div id="files-area">
                 <span id="filesList">
                     <span id="files-names"></span>
                 </span>
             </div>
-            <f:asset.script identifier="form_extended-fileupload" src="EXT:form_extended/Resources/Public/JavaScript/Frontend/FileUpload.js" />
-            <f:asset.css identifier="form_extended-fileupldad" href="EXT:form_extended/Resources/Public/CSS/FileUpload.css" />
+            <f:asset.script identifier="form_extended-fileupload" src="EXT:form_extended/Resources/Public/JavaScript/Frontend/FileUpload.js"/>
+            <f:asset.css identifier="form_extended-fileupldad" href="EXT:form_extended/Resources/Public/CSS/FileUpload.css"/>
         </f:if>
 
     </f:render>


### PR DESCRIPTION
This tries to solve #8 

What I did so far:
* Add a customized `UploadResourceViewHelper`. 
  *  Is an adapted version of the original from EXT:form
  *  Adapted is the method `getUploadedResource()`
  *  New is `addFileInFormFrontend()`

This solves the named bug. 

## BUT

### EmailFinisher fails
To make it working also an adaption in https://github.com/TYPO3/typo3/blob/10cbd42b3f67717e842233ddf8a6cb7a9af6af78/typo3/sysext/form/Classes/Domain/Finishers/EmailFinisher.php#L152-L155 is needed. It would need to become something like the following:

```php
if ($file instanceof FileReference) {
    $file = $file->getOriginalResource();
}
if (is_array($file)) {
    foreach ($file as $item) {

        if ($item instanceof FileReference) {
            $item = $item->getOriginalResource();
        }

        $mail->attach($item->getContents(), $item->getName(), $item->getMimeType());
    }
} else {
    $mail->attach($file->getContents(), $file->getName(), $file->getMimeType());
}
```
Therefore it might be the best to add a new finisher like `MultiUploadEmailFinisher` which contains this adaption. Has the downside that the editor needs to know that this finisher must be used...

### Failing when form is rerendered
Furthermore does it fail if you go back and forth in a multistep form or if a user violates a validator. I do not know how this work at all. Has someone a hint how EXT:form makes this working when using a single file? Does my solution from above break something?