### PR TITLE
fix fileupload hmac validation, handle multi or single property value…

### DIFF
--- a/Classes/Mvc/Property/TypeConverter/UploadedFileReferenceConverter.php
+++ b/Classes/Mvc/Property/TypeConverter/UploadedFileReferenceConverter.php
@@ -8,6 +8,7 @@ use TYPO3\CMS\Core\Http\UploadedFile;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Error\Error;
+use TYPO3\CMS\Form\Security\HashScope;
 use TYPO3\CMS\Extbase\Property\PropertyMappingConfigurationInterface;
 use TYPO3\CMS\Form\Mvc\Property\Exception\TypeConverterException;
 use TYPO3\CMS\Form\Mvc\Property\TypeConverter\PseudoFileReference;
@@ -70,7 +71,7 @@ class UploadedFileReferenceConverter extends \TYPO3\CMS\Form\Mvc\Property\TypeCo
                     try {
                         // File references use numeric resource pointers, direct
                         // file relations are using "file:" prefix (e.g. "file:5")
-                        $resourcePointer = $this->hashService->validateAndStripHmac($resourcePointerSource);
+                        $resourcePointer = $this->hashService->validateAndStripHmac($resourcePointerSource,HashScope::ResourcePointer->prefix());
                         if (strpos($resourcePointer, 'file:') === 0) {
                             $fileUid = (int)substr($resourcePointer, 5);
                             $resource = $this->createFileReferenceFromFalFileObject($this->resourceFactory->getFileObject($fileUid));

--- a/Classes/ViewHelpers/Form/UploadedResourceViewHelper.php
+++ b/Classes/ViewHelpers/Form/UploadedResourceViewHelper.php
@@ -104,15 +104,20 @@ class UploadedResourceViewHelper extends AbstractFormFieldViewHelper
         $this->tag->addAttribute('type', 'file');
 
         if (isset($this->arguments['multiple'])) {
+            $multiple = true;
             $this->tag->addAttribute('name', $name . '[]');
         } else {
             $this->tag->addAttribute('name', $name);
+            $multiple = false;
         }
 
         $this->setErrorClassAttribute();
         $output .= $this->tag->render();
 
         if ($resources !== null) {
+            if ($resources instanceof FileReference) {
+                $resources = [$resources];
+            }
             foreach ($resources as $key => $resource) {
                 $resourcePointerIdAttribute = '';
                 if ($this->hasArgument('id')) {
@@ -125,6 +130,9 @@ class UploadedResourceViewHelper extends AbstractFormFieldViewHelper
                     $resourcePointerValue = 'file:' . $resource->getOriginalResource()->getOriginalFile()->getUid();
                 }
                 $output .= '<input type="hidden" name="' . htmlspecialchars($this->getName()) . '[submittedFile][resourcePointer][]" value="' . htmlspecialchars($this->hashService->appendHmac((string)$resourcePointerValue, HashScope::ResourcePointer->prefix())) . '"' . $resourcePointerIdAttribute . ' />';
+            }
+            if ($multiple == false) {
+                $resources = reset($resources);
             }
             $this->templateVariableContainer->add($as, $resources);
             $output .= $this->renderChildren();
@@ -157,6 +165,8 @@ class UploadedResourceViewHelper extends AbstractFormFieldViewHelper
                 $ex = $this->propertyMapper->convert($resource, FileReference::class);
                 $return = array_merge($return, $ex);
             }
+        } elseif ($resources instanceof FileReference) {
+            return $resources;
         }
         return $return;
     }


### PR DESCRIPTION
1. Adds ResourcePointer prefix for hmac validation in UploadedFileReferenceConverter
2. Adjusted UploadedResourceViewHelper to resolve uploaded resources if multiupload is not enabled

fixes #32 